### PR TITLE
Yahoo! ID連携 V2対応とFaradayのwarning対応

### DIFF
--- a/lib/yahoo_store_api.rb
+++ b/lib/yahoo_store_api.rb
@@ -32,7 +32,7 @@ module YahooStoreApi
 
     private
 
-    ACCESS_TOKEN_ENDPOINT = "https://auth.login.yahoo.co.jp/yconnect/v1/token".freeze
+    ACCESS_TOKEN_ENDPOINT = "https://auth.login.yahoo.co.jp/yconnect/v2/token".freeze
 
     def access_token_connection
       Faraday.new(url: ACCESS_TOKEN_ENDPOINT) do |c|

--- a/lib/yahoo_store_api.rb
+++ b/lib/yahoo_store_api.rb
@@ -37,7 +37,7 @@ module YahooStoreApi
     def access_token_connection
       Faraday.new(url: ACCESS_TOKEN_ENDPOINT) do |c|
         c.adapter Faraday.default_adapter
-        c.authorization :Basic, Base64.strict_encode64("#{@application_id}:#{@application_secret}")
+        c.request :authorization, :Basic, Base64.strict_encode64("#{@application_id}:#{@application_secret}")
         c.headers["Content-Type"] = "application/x-www-form-urlencoded;charset=UTF-8"
       end
     end

--- a/test/cassettes/item/test_delete_item.yml
+++ b/test/cassettes/item/test_delete_item.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://auth.login.yahoo.co.jp/yconnect/v1/token
+    uri: https://auth.login.yahoo.co.jp/yconnect/v2/token
     body:
       encoding: UTF-8
       string: grant_type=refresh_token&refresh_token=<YOUR_REFRESH_TOKEN>
@@ -145,7 +145,7 @@ http_interactions:
   recorded_at: Thu, 11 May 2017 14:19:27 GMT
 - request:
     method: post
-    uri: https://auth.login.yahoo.co.jp/yconnect/v1/token
+    uri: https://auth.login.yahoo.co.jp/yconnect/v2/token
     body:
       encoding: UTF-8
       string: grant_type=refresh_token&refresh_token=<YOUR_REFRESH_TOKEN>
@@ -244,7 +244,7 @@ http_interactions:
   recorded_at: Thu, 11 May 2017 14:19:29 GMT
 - request:
     method: post
-    uri: https://auth.login.yahoo.co.jp/yconnect/v1/token
+    uri: https://auth.login.yahoo.co.jp/yconnect/v2/token
     body:
       encoding: UTF-8
       string: grant_type=refresh_token&refresh_token=<YOUR_REFRESH_TOKEN>

--- a/test/cassettes/item/test_edit_item.yml
+++ b/test/cassettes/item/test_edit_item.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://auth.login.yahoo.co.jp/yconnect/v1/token
+    uri: https://auth.login.yahoo.co.jp/yconnect/v2/token
     body:
       encoding: UTF-8
       string: grant_type=refresh_token&refresh_token=<YOUR_REFRESH_TOKEN>
@@ -145,7 +145,7 @@ http_interactions:
   recorded_at: Thu, 11 May 2017 13:50:37 GMT
 - request:
     method: post
-    uri: https://auth.login.yahoo.co.jp/yconnect/v1/token
+    uri: https://auth.login.yahoo.co.jp/yconnect/v2/token
     body:
       encoding: UTF-8
       string: grant_type=refresh_token&refresh_token=<YOUR_REFRESH_TOKEN>
@@ -245,7 +245,7 @@ http_interactions:
   recorded_at: Thu, 11 May 2017 13:50:39 GMT
 - request:
     method: post
-    uri: https://auth.login.yahoo.co.jp/yconnect/v1/token
+    uri: https://auth.login.yahoo.co.jp/yconnect/v2/token
     body:
       encoding: UTF-8
       string: grant_type=refresh_token&refresh_token=<YOUR_REFRESH_TOKEN>

--- a/test/cassettes/item/test_get_item.yml
+++ b/test/cassettes/item/test_get_item.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://auth.login.yahoo.co.jp/yconnect/v1/token
+    uri: https://auth.login.yahoo.co.jp/yconnect/v2/token
     body:
       encoding: UTF-8
       string: grant_type=refresh_token&refresh_token=<YOUR_REFRESH_TOKEN>

--- a/test/cassettes/item/test_if_dosent_exist_item_code.yml
+++ b/test/cassettes/item/test_if_dosent_exist_item_code.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://auth.login.yahoo.co.jp/yconnect/v1/token
+    uri: https://auth.login.yahoo.co.jp/yconnect/v2/token
     body:
       encoding: UTF-8
       string: grant_type=refresh_token&refresh_token=<YOUR_REFRESH_TOKEN>
@@ -98,7 +98,7 @@ http_interactions:
   recorded_at: Thu, 11 May 2017 14:51:01 GMT
 - request:
     method: post
-    uri: https://auth.login.yahoo.co.jp/yconnect/v1/token
+    uri: https://auth.login.yahoo.co.jp/yconnect/v2/token
     body:
       encoding: UTF-8
       string: grant_type=refresh_token&refresh_token=<YOUR_REFRESH_TOKEN>

--- a/test/cassettes/item/test_upload_item_file.yml
+++ b/test/cassettes/item/test_upload_item_file.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://auth.login.yahoo.co.jp/yconnect/v1/token
+    uri: https://auth.login.yahoo.co.jp/yconnect/v2/token
     body:
       encoding: UTF-8
       string: grant_type=refresh_token&refresh_token=<YOUR_REFRESH_TOKEN>

--- a/test/cassettes/item/upload_item_image_pack.yml
+++ b/test/cassettes/item/upload_item_image_pack.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://auth.login.yahoo.co.jp/yconnect/v1/token
+    uri: https://auth.login.yahoo.co.jp/yconnect/v2/token
     body:
       encoding: UTF-8
       string: grant_type=refresh_token&refresh_token=<YOUR_REFRESH_TOKEN>

--- a/test/cassettes/publish/test_reserve_publish.yml
+++ b/test/cassettes/publish/test_reserve_publish.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://auth.login.yahoo.co.jp/yconnect/v1/token
+    uri: https://auth.login.yahoo.co.jp/yconnect/v2/token
     body:
       encoding: UTF-8
       string: grant_type=refresh_token&refresh_token=<YOUR_REFRESH_TOKEN>

--- a/test/cassettes/stock/test_get_stock.yml
+++ b/test/cassettes/stock/test_get_stock.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://auth.login.yahoo.co.jp/yconnect/v1/token
+    uri: https://auth.login.yahoo.co.jp/yconnect/v2/token
     body:
       encoding: UTF-8
       string: grant_type=refresh_token&refresh_token=<YOUR_REFRESH_TOKEN>

--- a/test/cassettes/stock/test_set_stock.yml
+++ b/test/cassettes/stock/test_set_stock.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://auth.login.yahoo.co.jp/yconnect/v1/token
+    uri: https://auth.login.yahoo.co.jp/yconnect/v2/token
     body:
       encoding: UTF-8
       string: grant_type=refresh_token&refresh_token=<YOUR_REFRESH_TOKEN>
@@ -97,7 +97,7 @@ http_interactions:
   recorded_at: Thu, 11 May 2017 13:53:49 GMT
 - request:
     method: post
-    uri: https://auth.login.yahoo.co.jp/yconnect/v1/token
+    uri: https://auth.login.yahoo.co.jp/yconnect/v2/token
     body:
       encoding: UTF-8
       string: grant_type=refresh_token&refresh_token=<YOUR_REFRESH_TOKEN>


### PR DESCRIPTION
[Yahoo! ID連携 v2への移行](https://developer.yahoo.co.jp/changelog/2021-08-30-yconnect2.html)が必要なため、tokenの取得先をV2に変更しました。

また、`Faraday::Connection#authorization`のwarningが出ていましたので、warningが出ないように変更しました。

よろしくお願いします :bow: