### PR TITLE
refresh_tokenがなければauthorization_codeで取るしか無い

### DIFF
--- a/lib/yahoo_store_api.rb
+++ b/lib/yahoo_store_api.rb
@@ -27,7 +27,7 @@ module YahooStoreApi
       @application_id = application_id
       @application_secret = application_secret
       @redirect_uri = redirect_uri ? "&redirect_uri=" + CGI.escape(redirect_uri) : nil
-      @access_token = refresh_access_token(refresh_token) || get_access_token(authorization_code)
+      @access_token = refresh_token.present? ? refresh_access_token(refresh_token) : get_access_token(authorization_code)
     end
 
     private


### PR DESCRIPTION
refresh_tokenがない場合
{"error"=>"invalid_request", "error_description"=>"request is missing refresh_token parameter.", "error_code"=>1105}
が毎回出る
https://datatracker.ietf.org/doc/html/rfc6749#section-5.2